### PR TITLE
Change /cron/pull schedule 10 minutes -> 1 minute

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -1,6 +1,6 @@
 cron:
   - url: /cron/pull
-    schedule: every 10 minutes
+    schedule: every 1 minute
   - url: /cron/pull-plays
     schedule: every 1 minutes
   - url: /cron/refresh-play-medians


### PR DESCRIPTION
This is to counteract the recent decrease to the maximum number of items that can be retrieved in a single call: #96 