### PR TITLE
Disable autorun for :test target

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "test": "shadow-cljs compile test",
+    "test": "shadow-cljs compile test && node test.js",
     "repl": "shadow-cljs node-repl",
     "deps": "shadow-cljs classpath",
     "release:pull-games": "shadow-cljs release pull-games && esbuild pull-games.js --bundle --platform=node --target=node20 --external:pg-native --outfile=pull-games.dist.js",

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -9,8 +9,7 @@
  :builds
  {:test
   {:target :node-test
-   :output-to "test.js"
-   :autorun true}
+   :output-to "test.js"}
 
   :app
   {:target :node-script


### PR DESCRIPTION
This is to preserve the exit code of the tests